### PR TITLE
News page

### DIFF
--- a/WoloxAndroidBootstrp/app/src/main/AndroidManifest.xml
+++ b/WoloxAndroidBootstrp/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
             android:screenOrientation="portrait" />
 
         <activity android:name=".example.ui.news.NewsActivity"
+            android:parentActivityName=".example.ui.example.ExampleActivity"
             android:screenOrientation="portrait"/>
 
     </application>

--- a/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/model/NewResponse.kt
+++ b/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/model/NewResponse.kt
@@ -4,6 +4,7 @@ import java.io.Serializable
 
 class NewsResponse(
     val page: List<News>,
+    val message: String,
     val count: Long,
     val totalPages: Long,
     val totalCount: Long,

--- a/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/network/repository/NewsRepository.kt
+++ b/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/network/repository/NewsRepository.kt
@@ -11,10 +11,20 @@ class NewsRepository @Inject constructor(private val retrofitServices: RetrofitS
 
     var page: Int = 1
 
+    var id: Int = 0
+
     private val service: NewsService
         get() = retrofitServices.getService(NewsService::class.java)
 
     suspend fun getNews() = withContext(Dispatchers.IO) {
         NetworkRequestHandler.safeApiCall { service.getNews(page) }
+    }
+
+    suspend fun getSingleNewsItem() = withContext(Dispatchers.IO) {
+        NetworkRequestHandler.safeApiCall { service.getSingleNewsItem(id) }
+    }
+
+    suspend fun setLike() = withContext(Dispatchers.IO) {
+        NetworkRequestHandler.safeApiCall { service.setLike(id) }
     }
 }

--- a/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/network/services/NewsService.kt
+++ b/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/network/services/NewsService.kt
@@ -1,11 +1,20 @@
 package ar.com.wolox.android.example.network.services
 
+import ar.com.wolox.android.example.model.News
 import ar.com.wolox.android.example.model.NewsResponse
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.PUT
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface NewsService {
     @GET("/comments")
     suspend fun getNews(@Query("page")pageIndex: Int): Response<NewsResponse>
+
+    @GET("/comments/{id}")
+    suspend fun getSingleNewsItem(@Path("id") id: Int?): Response<News>
+
+    @PUT("/comments/like/{id}")
+    suspend fun setLike(@Path("id") id: Int?): Response<NewsResponse>
 }

--- a/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/example/ExampleFragment.kt
+++ b/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/example/ExampleFragment.kt
@@ -115,7 +115,6 @@ class ExampleFragment private constructor() : WolmoFragment<FragmentExampleBindi
     }
 
     override fun openBrowser(url: String) {
-
         requireContext().openBrowser(url)
     }
 

--- a/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/example/ExamplePresenter.kt
+++ b/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/example/ExamplePresenter.kt
@@ -26,11 +26,13 @@ class ExamplePresenter @Inject constructor(private val userSession: UserSession,
     private fun onLoginRequest(loginUserData: LoginUserData) = launch {
 
         networkRequest(loginRepository.loginPostRepo(loginUserData)) {
-            onResponseSuccessful { _ ->
+            onResponseSuccessful { response ->
 
                 userSession.apply {
                     username = loginUserData.email
                     password = loginUserData.password
+                    val userId = response?.data?.id
+                    id = userId?.toInt()
                     isOngoingSession = true
                 }
                 view?.goToViewPager(loginUserData.email)
@@ -49,7 +51,6 @@ class ExamplePresenter @Inject constructor(private val userSession: UserSession,
     }
 
     fun autoLogin() {
-
         if (userSession.username != null && userSession.password != null) {
             view?.goToViewPager("")
         }

--- a/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/news/NewsActivity.kt
+++ b/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/news/NewsActivity.kt
@@ -1,14 +1,20 @@
 package ar.com.wolox.android.example.ui.news
 
+import android.os.Bundle
 import ar.com.wolox.android.R
 import ar.com.wolox.android.databinding.ActivityBaseBinding
+import ar.com.wolox.android.example.model.News
+import ar.com.wolox.android.example.utils.Extras
 import ar.com.wolox.wolmo.core.activity.WolmoActivity
 
 class NewsActivity : WolmoActivity<ActivityBaseBinding>() {
 
     override fun layout() = R.layout.activity_base
 
+    override fun handleArguments(arguments: Bundle?) = arguments?.containsKey(Extras.News.KEY_NAME)
+
     override fun init() {
-        replaceFragment(binding.activityBaseContent.id, NewsFragment.newInstance())
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        replaceFragment(binding.activityBaseContent.id, NewsFragment.newInstance(requireArgument(Extras.News.KEY_NAME)))
     }
 }

--- a/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/news/NewsFragment.kt
+++ b/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/news/NewsFragment.kt
@@ -23,7 +23,6 @@ class NewsFragment @Inject constructor() : WolmoFragment<FragmentNewsBinding, Ne
     override fun handleArguments(arguments: Bundle?) = arguments?.containsKey(Extras.News.KEY_NAME)
 
     override fun init() {
-
         presenter.onInit(requireArgument(Extras.News.KEY_NAME))
         with(binding) {
             swipeRefreshNewsFragment.setOnRefreshListener(this@NewsFragment)
@@ -32,12 +31,9 @@ class NewsFragment @Inject constructor() : WolmoFragment<FragmentNewsBinding, Ne
 
     override fun setListeners() {
         binding.ButtonNewsCardFav.setOnClickListener {
-
             it.background = ContextCompat.getDrawable(requireContext(), R.drawable.ic_like_on)
-
             presenter.setLikeRequest()
         }
-
         super.setListeners()
     }
 

--- a/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/news/NewsFragment.kt
+++ b/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/news/NewsFragment.kt
@@ -1,18 +1,76 @@
 package ar.com.wolox.android.example.ui.news
 
+import android.os.Bundle
+import androidx.core.content.ContextCompat
+import androidx.core.os.bundleOf
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import ar.com.wolox.android.R
 import ar.com.wolox.android.databinding.FragmentNewsBinding
+import ar.com.wolox.android.example.model.News
+import ar.com.wolox.android.example.utils.Extras
+import ar.com.wolox.android.example.utils.RequestCode
 import ar.com.wolox.wolmo.core.fragment.WolmoFragment
+import ar.com.wolox.wolmo.core.util.ToastFactory
 import javax.inject.Inject
 
-class NewsFragment @Inject constructor() : WolmoFragment<FragmentNewsBinding, NewsPresenter>(), NewsView {
+class NewsFragment @Inject constructor() : WolmoFragment<FragmentNewsBinding, NewsPresenter>(), NewsView, SwipeRefreshLayout.OnRefreshListener {
+
+    @Inject
+    internal lateinit var toastFactory: ToastFactory
 
     override fun layout() = R.layout.fragment_news
 
+    override fun handleArguments(arguments: Bundle?) = arguments?.containsKey(Extras.News.KEY_NAME)
+
     override fun init() {
+
+        presenter.onInit(requireArgument(Extras.News.KEY_NAME))
+        with(binding) {
+            swipeRefreshNewsFragment.setOnRefreshListener(this@NewsFragment)
+        }
+    }
+
+    override fun setListeners() {
+        binding.ButtonNewsCardFav.setOnClickListener {
+
+            it.background = ContextCompat.getDrawable(requireContext(), R.drawable.ic_like_on)
+
+            presenter.setLikeRequest()
+        }
+
+        super.setListeners()
     }
 
     companion object {
-        fun newInstance() = NewsFragment()
+        fun newInstance(news: News) = NewsFragment().apply {
+            arguments = bundleOf(Extras.News.KEY_NAME to news)
+        }
+    }
+
+    override fun setUpUi(news: News) {
+        with(binding) {
+            etNewsTitle.text = news.id.toString()
+            etNewsDescripction.text = news.comment
+            ButtonNewsCardFav
+
+            presenter.setUpLikeButton(news, ButtonNewsCardFav, requireContext())
+        }
+    }
+
+    override fun showLoader(show: Boolean) {
+        if (!show) {
+            binding.swipeRefreshNewsFragment.isRefreshing = false
+        }
+    }
+
+    override fun showError(requestCode: RequestCode) {
+        when (requestCode) {
+            RequestCode.FAILED -> toastFactory.show(R.string.request_error_validation)
+            else -> toastFactory.show(R.string.default_error)
+        }
+    }
+
+    override fun onRefresh() {
+        presenter.refreshNewsItem()
     }
 }

--- a/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/news/NewsPresenter.kt
+++ b/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/news/NewsPresenter.kt
@@ -1,6 +1,52 @@
 package ar.com.wolox.android.example.ui.news
 
+import android.content.Context
+import android.widget.Button
+import androidx.core.content.ContextCompat
+import ar.com.wolox.android.R
+import ar.com.wolox.android.example.model.News
+import ar.com.wolox.android.example.network.builder.networkRequest
+import ar.com.wolox.android.example.network.repository.NewsRepository
+import ar.com.wolox.android.example.utils.RequestCode
+import ar.com.wolox.android.example.utils.UserSession
 import ar.com.wolox.wolmo.core.presenter.CoroutineBasePresenter
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-class NewsPresenter @Inject constructor() : CoroutineBasePresenter<NewsView>()
+class NewsPresenter @Inject constructor(private val newsRepository: NewsRepository, private val userSession: UserSession) : CoroutineBasePresenter<NewsView>() {
+
+    fun onInit(news: News) {
+        newsRepository.id = news.id.toInt()
+        view?.setUpUi(news)
+    }
+
+    fun refreshNewsItem() = launch {
+        networkRequest(newsRepository.getSingleNewsItem()) {
+            onResponseSuccessful { _ ->
+            }
+            onResponseFailed { _, _ -> view?.showError(RequestCode.FAILED) }
+            onCallFailure { view?.showError(RequestCode.FATALERROR) }
+        }
+        view?.showLoader(false)
+    }
+
+    fun setLikeRequest() = launch {
+        networkRequest(newsRepository.setLike()) {
+            onResponseSuccessful { _ ->
+            }
+            onResponseFailed { _, _ -> view?.showError(RequestCode.FAILED) }
+            onCallFailure { view?.showError(RequestCode.FATALERROR) }
+        }
+    }
+
+    fun setUpLikeButton(news: News, likeButton: Button, context: Context) {
+
+        if (news.likes.isNotEmpty()) {
+            if (news.likes.contains(userSession.id?.toLong())) {
+                likeButton.background = ContextCompat.getDrawable(context, R.drawable.ic_like_on)
+            } else {
+                likeButton.background = ContextCompat.getDrawable(context, R.drawable.ic_like_off)
+            }
+        }
+    }
+}

--- a/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/news/NewsView.kt
+++ b/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/news/NewsView.kt
@@ -1,3 +1,10 @@
 package ar.com.wolox.android.example.ui.news
 
-interface NewsView
+import ar.com.wolox.android.example.model.News
+import ar.com.wolox.android.example.utils.RequestCode
+
+interface NewsView {
+    fun setUpUi(news: News)
+    fun showLoader(show: Boolean)
+    fun showError(requestCode: RequestCode)
+}

--- a/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/viewpager/fragment/ViewPagerFragment.kt
+++ b/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/viewpager/fragment/ViewPagerFragment.kt
@@ -1,7 +1,6 @@
 package ar.com.wolox.android.example.ui.viewpager.fragment
 
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.core.os.bundleOf
 import androidx.viewpager.widget.ViewPager
@@ -54,10 +53,6 @@ class ViewPagerFragment private constructor() : WolmoFragment<FragmentViewpagerB
                 .setAction("Action", null)
                 .show()
         }
-
-        Log.e("user uid", "${userSession.uid}")
-        Log.e("user Access-Token", "${userSession.accessToken}")
-        Log.e("isOnGoing", "${ userSession.isOngoingSession}")
     }
 
     override fun setListeners() {

--- a/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/viewpager/random/RandomFragment.kt
+++ b/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/viewpager/random/RandomFragment.kt
@@ -10,13 +10,15 @@ import ar.com.wolox.android.R
 import ar.com.wolox.android.databinding.FragmentRandomBinding
 import ar.com.wolox.android.example.model.News
 import ar.com.wolox.android.example.ui.news.NewsActivity
+import ar.com.wolox.android.example.utils.Extras
 import ar.com.wolox.android.example.utils.RequestCode
+import ar.com.wolox.android.example.utils.UserSession
 import ar.com.wolox.wolmo.core.fragment.WolmoFragment
 import ar.com.wolox.wolmo.core.util.ToastFactory
 import java.util.ArrayList
 import javax.inject.Inject
 
-class RandomFragment @Inject constructor() : WolmoFragment<FragmentRandomBinding, RandomPresenter>(), RandomView,
+class RandomFragment @Inject constructor(private val userSession: UserSession) : WolmoFragment<FragmentRandomBinding, RandomPresenter>(), RandomView,
     SwipeRefreshLayout.OnRefreshListener {
 
     private var isLoading: Boolean = false
@@ -62,7 +64,7 @@ class RandomFragment @Inject constructor() : WolmoFragment<FragmentRandomBinding
         with(binding) {
             recyclerView.setHasFixedSize(true)
             recyclerView.layoutManager = layoutManager
-            adapter = RandomNewsRecyclerView()
+            adapter = RandomNewsRecyclerView(requireContext(), userSession)
             recyclerView.adapter = adapter
             recyclerView.addItemDecoration(
                 DividerItemDecoration(
@@ -73,9 +75,8 @@ class RandomFragment @Inject constructor() : WolmoFragment<FragmentRandomBinding
         }
         adapter.setOnItemClickListener(object : RandomNewsRecyclerView.onItemClickListener {
             override fun onItemClick(position: Int, news: News) {
-                toastFactory.show(news.commenter)
                 val intent = Intent(requireContext(), NewsActivity::class.java)
-                        .putExtra(getString(R.string.k_extra_news), news)
+                        .putExtra(Extras.News.KEY_NAME, news)
                 startActivity(intent)
             }
         })

--- a/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/viewpager/random/RandomFragment.kt
+++ b/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/viewpager/random/RandomFragment.kt
@@ -37,7 +37,6 @@ class RandomFragment @Inject constructor(private val userSession: UserSession) :
             layoutManager = LinearLayoutManager(requireContext())
             swipeRefresh.setOnRefreshListener(this@RandomFragment)
 
-            setUpRecycleView()
             presenter.getNewsRequest(false)
 
             recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
@@ -60,29 +59,26 @@ class RandomFragment @Inject constructor(private val userSession: UserSession) :
         }
     }
 
-    private fun setUpRecycleView() {
+    override fun getNews(list: ArrayList<News>) {
         with(binding) {
             recyclerView.setHasFixedSize(true)
             recyclerView.layoutManager = layoutManager
-            adapter = RandomNewsRecyclerView(requireContext(), userSession)
+            adapter = RandomNewsRecyclerView(requireContext(), userSession, list)
             recyclerView.adapter = adapter
             recyclerView.addItemDecoration(
-                DividerItemDecoration(
-                    requireContext(),
-                    DividerItemDecoration.VERTICAL
-                )
+                    DividerItemDecoration(
+                            requireContext(),
+                            DividerItemDecoration.VERTICAL
+                    )
             )
         }
-        adapter.setOnItemClickListener(object : RandomNewsRecyclerView.onItemClickListener {
+        adapter.setOnItemClickListener(object : RandomNewsRecyclerView.OnItemClickListener {
             override fun onItemClick(position: Int, news: News) {
                 val intent = Intent(requireContext(), NewsActivity::class.java)
                         .putExtra(Extras.News.KEY_NAME, news)
                 startActivity(intent)
             }
         })
-    }
-
-    override fun getNews(list: ArrayList<News>) {
         adapter.addData(list)
         binding.swipeRefresh.isRefreshing = false
     }

--- a/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/viewpager/random/RandomNewsRecyclerView.kt
+++ b/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/viewpager/random/RandomNewsRecyclerView.kt
@@ -19,17 +19,15 @@ import org.ocpsoft.prettytime.units.Minute
 import java.util.ArrayList
 import java.util.Date
 
-class RandomNewsRecyclerView(var context: Context, var userSession: UserSession) : RecyclerView.Adapter<RandomNewsRecyclerView.ViewHolder>() {
+class RandomNewsRecyclerView(var context: Context, var userSession: UserSession, var dataSet: ArrayList<News>) : RecyclerView.Adapter<RandomNewsRecyclerView.ViewHolder>() {
 
-    private var dataSet = ArrayList<News>()
+    private lateinit var mListener: OnItemClickListener
 
-    private lateinit var mListener: onItemClickListener
-
-    interface onItemClickListener {
+    interface OnItemClickListener {
         fun onItemClick(position: Int, news: News)
     }
 
-    fun setOnItemClickListener(listener: onItemClickListener) {
+    fun setOnItemClickListener(listener: OnItemClickListener) {
         mListener = listener
     }
 
@@ -55,7 +53,7 @@ class RandomNewsRecyclerView(var context: Context, var userSession: UserSession)
         notifyDataSetChanged()
     }
 
-    inner class ViewHolder(val view: View, listener: onItemClickListener) : RecyclerView.ViewHolder(view) {
+    inner class ViewHolder(val view: View, listener: OnItemClickListener) : RecyclerView.ViewHolder(view) {
 
         init {
             view.setOnClickListener {

--- a/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/viewpager/random/RandomNewsRecyclerView.kt
+++ b/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/ui/viewpager/random/RandomNewsRecyclerView.kt
@@ -1,21 +1,25 @@
 package ar.com.wolox.android.example.ui.viewpager.random
 
+import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import ar.com.wolox.android.R
 import ar.com.wolox.android.example.model.News
 import ar.com.wolox.android.example.utils.CustomTimeFormat
+import ar.com.wolox.android.example.utils.UserSession
 import com.bumptech.glide.Glide
 import org.ocpsoft.prettytime.PrettyTime
 import org.ocpsoft.prettytime.units.Minute
 import java.util.ArrayList
 import java.util.Date
 
-class RandomNewsRecyclerView() : RecyclerView.Adapter<RandomNewsRecyclerView.ViewHolder>() {
+class RandomNewsRecyclerView(var context: Context, var userSession: UserSession) : RecyclerView.Adapter<RandomNewsRecyclerView.ViewHolder>() {
 
     private var dataSet = ArrayList<News>()
 
@@ -72,6 +76,16 @@ class RandomNewsRecyclerView() : RecyclerView.Adapter<RandomNewsRecyclerView.Vie
 
             val tvCardDescription: TextView = view.findViewById(R.id.tvCardDescription)
             tvCardDescription.text = news.comment
+
+            val likeButton: Button = view.findViewById(R.id.Button_CardFav)
+
+            if (news.likes.isNotEmpty()) {
+                if (news.likes.contains(userSession.id?.toLong())) {
+                    likeButton.background = ContextCompat.getDrawable(context, R.drawable.ic_like_on)
+                } else {
+                    likeButton.background = ContextCompat.getDrawable(context, R.drawable.ic_like_off)
+                }
+            }
 
             val imageViewCard: ImageView = view.findViewById(R.id.ivCard)
             Glide.with(view).load("http://goo.gl/gEgYUd").placeholder(R.drawable.ic_image_not_supported).into(imageViewCard)

--- a/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/utils/Extras.kt
+++ b/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/utils/Extras.kt
@@ -16,10 +16,15 @@ object Extras {
         const val HEADER_ACCESS_TOKEN = "Access-Token"
         const val HEADER_CLIENT = "Client"
         const val HEADER_UID = "Uid"
+        const val USER_ID = "id"
         const val IS_ON_GOING_SESSION = "IS_ON_GOING_SESSION"
     }
 
     object ViewPager {
         const val FAVOURITE_COLOR_KEY = "FAVOURITE_COLOR_KEY"
+    }
+
+    object News {
+        const val KEY_NAME = "NEWS"
     }
 }

--- a/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/utils/UserSession.kt
+++ b/WoloxAndroidBootstrp/app/src/main/java/ar/com/wolox/android/example/utils/UserSession.kt
@@ -64,4 +64,11 @@ class UserSession @Inject constructor(private val sharedPreferencesManager: Shar
             field = uid
             sharedPreferencesManager.store(Extras.UserLogin.HEADER_UID, uid)
         }
+
+    var id: Int? = null
+        get() = field ?: sharedPreferencesManager[Extras.UserLogin.USER_ID, 0]
+        set(id) {
+            field = id
+            id?.let { sharedPreferencesManager.store(Extras.UserLogin.USER_ID, it) }
+        }
 }

--- a/WoloxAndroidBootstrp/app/src/main/res/layout/fragment_news.xml
+++ b/WoloxAndroidBootstrp/app/src/main/res/layout/fragment_news.xml
@@ -10,18 +10,11 @@
         android:layout_height="match_parent">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_fragment_news"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:gravity="center"
         android:orientation="vertical">
-
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/toolbar_news"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent"
-        app:navigationIcon="?attr/homeAsUpIndicator">
-    </androidx.appcompat.widget.Toolbar>
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -38,6 +31,15 @@
             android:scaleType="centerCrop"
             android:contentDescription="@string/iv_cover_fragment_news">
         </ImageView>
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar_news"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/cl_fragment_news"
+            app:navigationIcon="?attr/homeAsUpIndicator">
+        </androidx.appcompat.widget.Toolbar>
+
 
         <TextView
             android:id="@+id/etNewsTitle"

--- a/WoloxAndroidBootstrp/app/src/main/res/layout/fragment_news.xml
+++ b/WoloxAndroidBootstrp/app/src/main/res/layout/fragment_news.xml
@@ -4,21 +4,68 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
-        <TextView
-            android:id="@+id/etNews"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/spacing_large_extra"
-            android:layout_marginTop="316dp"
-            android:layout_marginRight="@dimen/spacing_large_extra"
-            android:gravity="center"
-            android:inputType="text"
-            android:maxLines="1"
-            android:text="Hello World"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.636"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_chainStyle="packed" />
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefresh_news_fragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:orientation="vertical">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar_news"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navigationIcon="?attr/homeAsUpIndicator">
+    </androidx.appcompat.widget.Toolbar>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:weightSum="100">
+
+        <ImageView
+            android:id="@+id/image"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/spacing_none"
+            android:layout_weight="60"
+            android:background="@color/chuck_colorAccent"
+            android:scaleType="centerCrop"
+            android:contentDescription="@string/iv_cover_fragment_news">
+        </ImageView>
+
+        <TextView
+            android:id="@+id/etNewsTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/font_medium"
+            android:layout_marginTop="@dimen/font_large"
+            android:textSize="@dimen/font_large_extra"
+            android:textStyle="bold"
+            tools:text="Title" />
+
+        <TextView
+            android:id="@+id/etNewsDescripction"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/font_medium"
+            android:layout_marginTop="@dimen/font_large"
+            android:textSize="@dimen/font_large_extra"
+            tools:text="Description" />
+
+        <Button
+            android:id="@+id/Button_News_CardFav"
+            android:layout_width="@dimen/spacing_big_extra"
+            android:layout_height="@dimen/spacing_big_extra"
+            android:layout_gravity="center"
+            android:layout_marginTop="@dimen/static_spacing_largest_extra"
+            android:background="@drawable/like_button_selector" />
+    </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </layout>

--- a/WoloxAndroidBootstrp/app/src/main/res/layout/fragment_random.xml
+++ b/WoloxAndroidBootstrp/app/src/main/res/layout/fragment_random.xml
@@ -7,10 +7,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <ScrollView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/constrain_layout"
                 android:layout_width="match_parent"
@@ -41,6 +37,5 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
-        </ScrollView>
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </layout>

--- a/WoloxAndroidBootstrp/app/src/main/res/layout/fragment_random.xml
+++ b/WoloxAndroidBootstrp/app/src/main/res/layout/fragment_random.xml
@@ -7,35 +7,35 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/constrain_layout"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/constrain_layout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="@dimen/spacing_large">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recycler_view"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:padding="@dimen/spacing_large">
+                android:layout_height="wrap_content"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/recycler_view"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+            <ProgressBar
+                android:id="@+id/pbRecyclerView"
+                style="?android:attr/progressBarStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_large"
+                android:background="@android:color/transparent"
+                android:gravity="center_horizontal|bottom"
+                android:indeterminateTint="@color/colorPrimary"
+                android:visibility="invisible"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
 
-                <ProgressBar
-                    android:id="@+id/pbRecyclerView"
-                    style="?android:attr/progressBarStyle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/spacing_large"
-                    android:background="@android:color/transparent"
-                    android:gravity="center_horizontal|bottom"
-                    android:indeterminateTint="@color/colorPrimary"
-                    android:visibility="invisible"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </layout>

--- a/WoloxAndroidBootstrp/app/src/main/res/layout/text_row_item.xml
+++ b/WoloxAndroidBootstrp/app/src/main/res/layout/text_row_item.xml
@@ -2,8 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="100dp"
-    android:layout_marginBottom="8dp"
+    android:layout_height="@dimen/static_spacing_largest_extra"
+    android:layout_marginBottom="@dimen/static_spacing_medium"
     android:orientation="horizontal">
 
     <LinearLayout
@@ -12,17 +12,17 @@
 
         <ImageView
             android:id="@+id/ivCard"
-            android:layout_width="60dp"
-            android:layout_height="60dp"
+            android:layout_width="@dimen/static_spacing_huge_extra"
+            android:layout_height="@dimen/static_spacing_huge_extra"
             android:layout_gravity="center_vertical"
-            android:layout_margin="20dp"
+            android:layout_margin="@dimen/static_spacing_large"
             android:contentDescription="@string/card_card_img_description" />
     </LinearLayout>
 
     <LinearLayout
-        android:layout_width="180dp"
+        android:layout_width="@dimen/static_spacing_largest_extra_extra"
         android:layout_height="match_parent"
-        android:layout_marginRight="@dimen/spacing_large_extra"
+        android:layout_marginEnd="@dimen/spacing_large_extra"
         android:gravity="center_vertical"
         android:orientation="vertical">
 
@@ -47,7 +47,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginRight="@dimen/spacing_large"
+        android:layout_marginEnd="@dimen/spacing_large"
         android:gravity="center_vertical"
         android:orientation="vertical">
 
@@ -56,12 +56,12 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical|end"
-            android:text="@string/fragment_viewpager_card_createdtime_demo" />
+            tools:text="@string/fragment_viewpager_card_createdtime_demo" />
 
         <Button
             android:id="@+id/Button_CardFav"
-            android:layout_width="30dp"
-            android:layout_height="30dp"
+            android:layout_width="@dimen/static_spacing_large_extra"
+            android:layout_height="@dimen/static_spacing_large_extra"
             android:layout_gravity="center_vertical|end"
             android:background="@drawable/like_button_selector" />
     </LinearLayout>

--- a/WoloxAndroidBootstrp/app/src/main/res/values/dimens.xml
+++ b/WoloxAndroidBootstrp/app/src/main/res/values/dimens.xml
@@ -13,6 +13,7 @@
     <dimen name="static_spacing_huge_extra">60dp</dimen>
     <dimen name="static_spacing_largest">72dp</dimen>
     <dimen name="static_spacing_largest_extra">100dp</dimen>
+    <dimen name="static_spacing_largest_extra_extra">180dp</dimen>
 
 
     <!-- Spacing -->

--- a/WoloxAndroidBootstrp/app/src/main/res/values/strings.xml
+++ b/WoloxAndroidBootstrp/app/src/main/res/values/strings.xml
@@ -33,5 +33,6 @@
     <string name="card_card_img_description">CardImg</string>
     <string name="fragment_viewpager_card_createdtime_demo">15seg</string>
     <string name="k_extra_news">Key_News</string>
+    <string name="iv_cover_fragment_news">iv_cover_fragment_news</string>
 
 </resources>


### PR DESCRIPTION
### Summary

- News page UI
- Clicking on recycler view item navigates to News Page with item data show in UI.
- Swipe on refresh when pull up, reload screen requesting to backend (/comments/:id)
 -Saving user id when logs in to validate users favorite news when these are shown with recycle view.
- If "like" button is clicked, send request to endpoint comments/like/:id. When refreshing recycle view updates favorite new on UI. 


<img width="398" alt="Captura de Pantalla 2021-09-01 a la(s) 13 16 21" src="https://user-images.githubusercontent.com/67754575/131706828-e66c60b3-70fb-4162-97a2-bac3687e7b88.png">


### Trello
https://trello.com/c/3m13UkF9/8-u6-frontend-and-backend-news-detail


